### PR TITLE
useOnlyInput 적용

### DIFF
--- a/src/components/search/Searchform.tsx
+++ b/src/components/search/Searchform.tsx
@@ -4,24 +4,20 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { RootState } from '../../redux/configStore';
 import { newsActions, fetchBySearch } from '../../redux/modules/newsSlice';
+import useOnlyInput from '../../hooks/useOnlyInput';
 
 const Searchform = () => {
-	const [input, setInput] = useState<string>('');
+	const [input, setInput, changeInputHandler] = useOnlyInput("");
 	const selector = useSelector((state: RootState) => state.news.news);
 	const dispatch = useDispatch<any>();
 	const navigate = useNavigate();
 	const pathname = useLocation().pathname;
 	const inputRef = useRef<HTMLInputElement | null>(null);
 
-	const inputChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
-		setInput(e.target.value);
-	};
-
 	const inputSubmitHandler = (e: React.FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
 
 		dispatch(newsActions.setInput(input));
-		// dispatch(newsActions.setDefaultNews());
 
 		if (!input) navigate('/viewer/topheadline');
 		else navigate(`/viewer/${input}`);
@@ -37,7 +33,7 @@ const Searchform = () => {
 
 	return (
 		<SearchFormWrapper onSubmit={inputSubmitHandler}>
-			<SearchFormInput onChange={inputChangeHandler} value={input} ref={inputRef} placeholder="주제를 검색하세요!😁" />
+			<SearchFormInput onChange={changeInputHandler} value={input} ref={inputRef} placeholder="주제를 검색하세요!😁" />
 			<SearchFormButton type="submit">확인</SearchFormButton>
 		</SearchFormWrapper>
 	);

--- a/src/components/search/Searchform.tsx
+++ b/src/components/search/Searchform.tsx
@@ -7,7 +7,7 @@ import { newsActions, fetchBySearch } from '../../redux/modules/newsSlice';
 import useOnlyInput from '../../hooks/useOnlyInput';
 
 const Searchform = () => {
-	const [input, setInput, changeInputHandler] = useOnlyInput("");
+	const [input, setInput, changeInputHandler] = useOnlyInput('');
 	const selector = useSelector((state: RootState) => state.news.news);
 	const dispatch = useDispatch<any>();
 	const navigate = useNavigate();

--- a/src/hooks/useOnlyInput.ts
+++ b/src/hooks/useOnlyInput.ts
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react';
 
-const useOnlyInput = (initialState: string) => {
+const useOnlyInput = (initialState: string):[string, React.Dispatch<React.SetStateAction<string>>, React.ChangeEventHandler<HTMLInputElement>] => {
 	const [state, setState] = useState(initialState);
 	const changeHandler = useCallback(
 		(e: React.ChangeEvent<HTMLInputElement>) => {
@@ -9,6 +9,6 @@ const useOnlyInput = (initialState: string) => {
 		},
 		[state],
 	);
-	return [state, changeHandler];
+	return [state, setState, changeHandler];
 };
 export default useOnlyInput;

--- a/src/hooks/useOnlyInput.ts
+++ b/src/hooks/useOnlyInput.ts
@@ -1,6 +1,8 @@
 import React, { useState, useCallback } from 'react';
 
-const useOnlyInput = (initialState: string):[string, React.Dispatch<React.SetStateAction<string>>, React.ChangeEventHandler<HTMLInputElement>] => {
+const useOnlyInput = (
+	initialState: string,
+): [string, React.Dispatch<React.SetStateAction<string>>, React.ChangeEventHandler<HTMLInputElement>] => {
 	const [state, setState] = useState(initialState);
 	const changeHandler = useCallback(
 		(e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## 해결한 이슈

- 커스텀 훅 useOnlyInput 적용

<br />

## 해결 방법

- 기존의 change 이벤트 핸들러를 삭제하고 useOnlyInput이 반환하는 change 이벤트 핸들러를 등록해주었고, input을 관리하는 state 또한 useOnlyInput에서 반환하는 값으로 적용이 되도록 변환

<br />

## 코드

```tsx
const Searchform = () => {
	const [input, setInput, changeInputHandler] = useOnlyInput('');
	const selector = useSelector((state: RootState) => state.news.news);
	const dispatch = useDispatch<any>();
	const navigate = useNavigate();
	const pathname = useLocation().pathname;
	const inputRef = useRef<HTMLInputElement | null>(null);

	const inputSubmitHandler = (e: React.FormEvent<HTMLFormElement>) => {
		e.preventDefault();

		dispatch(newsActions.setInput(input));

		if (!input) navigate('/viewer/topheadline');
		else navigate(`/viewer/${input}`);
	};

	useEffect(() => {
		if (pathname === '/viewer/topheadline') {
			setInput('');
			dispatch(newsActions.setDefaultInput());
			inputRef.current!.focus();
		}
	}, [pathname]);

	return (
		<SearchFormWrapper onSubmit={inputSubmitHandler}>
			<SearchFormInput onChange={changeInputHandler} value={input} ref={inputRef} placeholder="주제를 검색하세요!😁" />
			<SearchFormButton type="submit">확인</SearchFormButton>
		</SearchFormWrapper>
	);
};

export default Searchform;
```

<br />

## 추가적인 태스크

- 기존 useOnlyInput.ts에서는 setState를 반환하지 않았으나 입력된 input을 빈 문자열로 바꿔야하는 기능이 필요하여 setState를 반환하는 것을 추가하였고, 반환 타입을 명시해줌.

<br />
<br />

## PR Submit 이전에 확인하세요 !

`체크리스트`

- [] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다.
