### PR TITLE
FIX: 뉴스 리스트가 중첩되어 컴포넌트 key 값이 중복되어 오류가 발생하는 현상 수정

### DIFF
--- a/src/components/search/Searchform.tsx
+++ b/src/components/search/Searchform.tsx
@@ -26,7 +26,6 @@ const Searchform = () => {
 	useEffect(() => {
 		if (pathname === '/viewer/topheadline') {
 			setInput('');
-			dispatch(newsActions.setDefaultInput());
 			inputRef.current!.focus();
 		}
 	}, [pathname]);


### PR DESCRIPTION
## 해결한 이슈

- #3

<br />

## 해결 방법

- SearchForm.tsx에서 input을 빈 문자열로 초기화하는 로직을 삭제

<br />
<br />

## PR Submit 이전에 확인하세요 !

`체크리스트`

- [] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다.
